### PR TITLE
SAR-2226: Create new SubmissionService

### DIFF
--- a/app/uk/gov/hmrc/vatsignup/services/SubmissionService.scala
+++ b/app/uk/gov/hmrc/vatsignup/services/SubmissionService.scala
@@ -1,0 +1,147 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignup.services
+
+import cats.data._
+import cats.implicits._
+import javax.inject.{Inject, Singleton}
+import play.api.mvc.Request
+import uk.gov.hmrc.auth.core.Enrolments
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.vatsignup.connectors.{CustomerSignUpConnector, RegistrationConnector, TaxEnrolmentsConnector}
+import uk.gov.hmrc.vatsignup.httpparsers.RegisterWithMultipleIdentifiersHttpParser.RegisterWithMultipleIdsSuccess
+import uk.gov.hmrc.vatsignup.httpparsers.TaxEnrolmentsHttpParser.SuccessfulTaxEnrolment
+import uk.gov.hmrc.vatsignup.models.{CustomerSignUpResponseSuccess, SignUpRequest}
+import uk.gov.hmrc.vatsignup.models.SignUpRequest._
+import uk.gov.hmrc.vatsignup.models.monitoring.RegisterWithMultipleIDsAuditing.RegisterWithMultipleIDsAuditModel
+import uk.gov.hmrc.vatsignup.models.monitoring.SignUpAuditing.SignUpAuditModel
+import uk.gov.hmrc.vatsignup.repositories.SubscriptionRequestRepository
+import uk.gov.hmrc.vatsignup.services.SubmissionService._
+import uk.gov.hmrc.vatsignup.services.monitoring.AuditService
+import uk.gov.hmrc.vatsignup.utils.EnrolmentUtils._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class SubmissionService @Inject()(subscriptionRequestRepository: SubscriptionRequestRepository,
+                                  customerSignUpConnector: CustomerSignUpConnector,
+                                  registrationConnector: RegistrationConnector,
+                                  taxEnrolmentsConnector: TaxEnrolmentsConnector,
+                                  auditService: AuditService
+                                 )(implicit ec: ExecutionContext) {
+
+  def submitSignUpRequest(signUpRequest: SignUpRequest,
+                          enrolments: Enrolments
+                         )(implicit hc: HeaderCarrier,
+                           request: Request[_]): Future[SignUpRequestSubmissionResponse] = {
+
+    val optAgentReferenceNumber = enrolments.agentReferenceNumber
+    val email = signUpRequest.signUpEmail map { _.emailAddress }
+    val isSignUpVerified = signUpRequest.signUpEmail map { _.isVerified }
+
+    val result = for {
+      safeId <- signUpRequest.businessEntity match {
+        case x: LimitedCompany =>
+          registerCompany(signUpRequest.vatNumber, x.companyNumber, optAgentReferenceNumber)
+        case x: SoleTrader =>
+          registerIndividual(signUpRequest.vatNumber, x.nino, optAgentReferenceNumber)
+      }
+      _ <- signUp(safeId, signUpRequest.vatNumber, email, isSignUpVerified, optAgentReferenceNumber)
+      _ <- registerEnrolment(signUpRequest.vatNumber, safeId)
+    } yield SignUpRequestSubmitted
+
+    result.value
+  }
+
+  private def registerCompany(
+                               vatNumber: String,
+                               companyNumber: String,
+                               agentReferenceNumber: Option[String]
+                             )(implicit hc: HeaderCarrier, request: Request[_]): EitherT[Future, SignUpRequestSubmissionFailure, String] =
+    EitherT(registrationConnector.registerCompany(vatNumber, companyNumber)) bimap( {
+      _ => {
+        auditService.audit(RegisterWithMultipleIDsAuditModel(vatNumber, Some(companyNumber), None, agentReferenceNumber, isSuccess = false))
+        RegistrationFailure
+      }
+    }, {
+      case RegisterWithMultipleIdsSuccess(safeId) => {
+        auditService.audit(RegisterWithMultipleIDsAuditModel(vatNumber, Some(companyNumber), None, agentReferenceNumber, isSuccess = true))
+        safeId
+      }
+    })
+
+  private def registerIndividual(
+                                  vatNumber: String,
+                                  nino: String,
+                                  agentReferenceNumber: Option[String]
+                                )(implicit hc: HeaderCarrier, request: Request[_]): EitherT[Future, SignUpRequestSubmissionFailure, String] =
+    EitherT(registrationConnector.registerIndividual(vatNumber, nino)) bimap( {
+      _ => {
+        auditService.audit(RegisterWithMultipleIDsAuditModel(vatNumber, None, Some(nino), agentReferenceNumber, isSuccess = false))
+        RegistrationFailure
+      }
+    }, {
+      case RegisterWithMultipleIdsSuccess(safeId) => {
+        auditService.audit(RegisterWithMultipleIDsAuditModel(vatNumber, None, Some(nino), agentReferenceNumber, isSuccess = true))
+        safeId
+      }
+    })
+
+  private def signUp(safeId: String,
+                     vatNumber: String,
+                     emailAddress: Option[String],
+                     emailAddressVerified: Option[Boolean],
+                     agentReferenceNumber: Option[String]
+                    )(implicit hc: HeaderCarrier, request: Request[_]): EitherT[Future, SignUpRequestSubmissionFailure, CustomerSignUpResponseSuccess.type] =
+    EitherT(customerSignUpConnector.signUp(safeId, vatNumber, emailAddress, emailAddressVerified)) bimap( {
+      _ => {
+        auditService.audit(SignUpAuditModel(safeId, vatNumber, emailAddress, emailAddressVerified, agentReferenceNumber, isSuccess = false))
+        SignUpFailure
+      }
+    }, {
+      customerSignUpSuccess => {
+        auditService.audit(SignUpAuditModel(safeId, vatNumber, emailAddress, emailAddressVerified, agentReferenceNumber, isSuccess = true))
+        customerSignUpSuccess
+      }
+    })
+
+  private def registerEnrolment(
+                                 vatNumber: String,
+                                 safeId: String
+                               )(implicit hc: HeaderCarrier): EitherT[Future, SignUpRequestSubmissionFailure, SuccessfulTaxEnrolment.type] = {
+    EitherT(taxEnrolmentsConnector.registerEnrolment(vatNumber, safeId)) leftMap {
+      _ => EnrolmentFailure
+    }
+  }
+
+}
+
+object SubmissionService {
+
+  type SignUpRequestSubmissionResponse = Either[SignUpRequestSubmissionFailure, SignUpRequestSubmitted.type]
+
+  case object SignUpRequestSubmitted
+
+  sealed trait SignUpRequestSubmissionFailure
+
+  case object SignUpFailure extends SignUpRequestSubmissionFailure
+
+  case object RegistrationFailure extends SignUpRequestSubmissionFailure
+
+  case object EnrolmentFailure extends SignUpRequestSubmissionFailure
+
+}

--- a/test/uk/gov/hmrc/vatsignup/helpers/TestConstants.scala
+++ b/test/uk/gov/hmrc/vatsignup/helpers/TestConstants.scala
@@ -22,6 +22,7 @@ import uk.gov.hmrc.auth.core.Enrolment
 import uk.gov.hmrc.vatsignup.config.Constants._
 import uk.gov.hmrc.vatsignup.httpparsers.KnownFactsAndControlListInformationHttpParser.KnownFactsAndControlListInformation
 import uk.gov.hmrc.vatsignup.models.ControlListInformation.{Company, Stagger1}
+import uk.gov.hmrc.vatsignup.models.SignUpRequest.{LimitedCompany, SoleTrader, EmailAddress}
 import uk.gov.hmrc.vatsignup.models.{ControlListInformation, CustomerDetails}
 import uk.gov.hmrc.vatsignup.utils.controllist.ControlListInformationParser.ControlListInformationIndices._
 
@@ -36,6 +37,9 @@ object TestConstants {
   val testSafeId: String = UUID.randomUUID().toString
   val testToken = UUID.randomUUID().toString
   val testJourneyLink = s"/mdtp/journey/journeyId/${UUID.randomUUID().toString}"
+  val testBusinessEntityLTD = LimitedCompany(testCompanyNumber)
+  val testBusinessEntitySole = SoleTrader(testNino)
+  val testSignUpEmail = EmailAddress(testEmail, true)
 
   val testPostCode = "ZZ11 1ZZ"
   val testDateOfRegistration = "2017-01-01"

--- a/test/uk/gov/hmrc/vatsignup/service/SubmissionServiceSpec.scala
+++ b/test/uk/gov/hmrc/vatsignup/service/SubmissionServiceSpec.scala
@@ -1,0 +1,307 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignup.service
+
+import org.scalatest.EitherValues
+import play.api.http.Status._
+import play.api.test.FakeRequest
+import reactivemongo.api.commands.{UpdateWriteResult, WriteResult}
+import uk.gov.hmrc.auth.core.Enrolments
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.vatsignup.connectors.mocks.{MockCustomerSignUpConnector, MockRegistrationConnector, MockTaxEnrolmentsConnector}
+import uk.gov.hmrc.vatsignup.helpers.TestConstants
+import uk.gov.hmrc.vatsignup.helpers.TestConstants._
+import uk.gov.hmrc.vatsignup.httpparsers.RegisterWithMultipleIdentifiersHttpParser._
+import uk.gov.hmrc.vatsignup.httpparsers.TaxEnrolmentsHttpParser._
+import uk.gov.hmrc.vatsignup.models._
+import uk.gov.hmrc.vatsignup.models.monitoring.RegisterWithMultipleIDsAuditing.RegisterWithMultipleIDsAuditModel
+import uk.gov.hmrc.vatsignup.models.monitoring.SignUpAuditing.SignUpAuditModel
+import uk.gov.hmrc.vatsignup.repositories.mocks.{MockEmailRequestRepository, MockSubscriptionRequestRepository}
+import uk.gov.hmrc.vatsignup.service.mocks.MockEmailRequirementService
+import uk.gov.hmrc.vatsignup.service.mocks.monitoring.MockAuditService
+import uk.gov.hmrc.vatsignup.services.EmailRequirementService.{Email, GetEmailVerificationFailure, UnVerifiedEmail}
+import uk.gov.hmrc.vatsignup.services.SubmissionService._
+import uk.gov.hmrc.vatsignup.services._
+
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class SubmissionServiceSpec extends UnitSpec with EitherValues
+  with MockSubscriptionRequestRepository with MockEmailRequirementService
+  with MockCustomerSignUpConnector with MockRegistrationConnector
+  with MockTaxEnrolmentsConnector with MockAuditService with MockEmailRequestRepository {
+
+  object TestSubmissionService extends SubmissionService(
+    mockSubscriptionRequestRepository,
+    mockCustomerSignUpConnector,
+    mockRegistrationConnector,
+    mockTaxEnrolmentsConnector,
+    mockAuditService
+  )
+
+
+  private implicit val hc: HeaderCarrier = HeaderCarrier()
+  private implicit val request = FakeRequest("POST", "testUrl")
+
+  "submitSignUpRequest" when {
+    "the user is a delegate and " when {
+      val enrolments = Enrolments(Set(testAgentEnrolment))
+
+      "the registration request is successful" when {
+        "the sign up request is successful" when {
+          "the enrolment call is successful" should {
+            "return a SignUpRequestSubmitted for an individual signup" in {
+
+              val signUpRequest = SignUpRequest(
+                vatNumber = testVatNumber,
+                businessEntity = testBusinessEntitySole,
+                signUpEmail = Some(testSignUpEmail),
+                transactionEmail = testSignUpEmail,
+                isDelegated = true
+              )
+
+
+              mockRegisterIndividual(testVatNumber, testNino)(Future.successful(Right(RegisterWithMultipleIdsSuccess(testSafeId))))
+
+              mockSignUp(testSafeId, testVatNumber, Some(testEmail), emailVerified = Some(true))(Future.successful(Right(CustomerSignUpResponseSuccess)))
+              mockRegisterEnrolment(testVatNumber, testSafeId)(Future.successful(Right(SuccessfulTaxEnrolment)))
+
+              val res = await(TestSubmissionService.submitSignUpRequest(signUpRequest, enrolments))
+              res.right.value shouldBe SignUpRequestSubmitted
+
+              verifyAudit(RegisterWithMultipleIDsAuditModel(TestConstants.testVatNumber, None, Some(TestConstants.testNino),
+                Some(TestConstants.testAgentReferenceNumber), isSuccess = true))
+            }
+            "return a SignUpRequestSubmitted for a company sign up" in {
+              val signUpRequest = SignUpRequest(
+                vatNumber = testVatNumber,
+                businessEntity = testBusinessEntityLTD,
+                signUpEmail = Some(testSignUpEmail),
+                transactionEmail = testSignUpEmail,
+                isDelegated = true
+              )
+
+              mockRegisterCompany(testVatNumber, testCompanyNumber)(Future.successful(Right(RegisterWithMultipleIdsSuccess(testSafeId))))
+              mockSignUp(testSafeId, testVatNumber, Some(testEmail), emailVerified = Some(true))(Future.successful(Right(CustomerSignUpResponseSuccess)))
+              mockRegisterEnrolment(testVatNumber, testSafeId)(Future.successful(Right(SuccessfulTaxEnrolment)))
+
+              val res = await(TestSubmissionService.submitSignUpRequest(signUpRequest, enrolments))
+
+              res.right.value shouldBe SignUpRequestSubmitted
+
+              verifyAudit(RegisterWithMultipleIDsAuditModel(TestConstants.testVatNumber, Some(TestConstants.testCompanyNumber), None,
+                Some(TestConstants.testAgentReferenceNumber), isSuccess = true))
+              verifyAudit(SignUpAuditModel(TestConstants.testSafeId, TestConstants.testVatNumber, Some(TestConstants.testEmail), Some(true),
+                Some(TestConstants.testAgentReferenceNumber), isSuccess = true))
+            }
+          }
+          "the enrolment call fails" should {
+            "return an EnrolmentFailure" in {
+              val signUpRequest = SignUpRequest(
+                vatNumber = testVatNumber,
+                businessEntity = testBusinessEntityLTD,
+                signUpEmail = Some(testSignUpEmail),
+                transactionEmail = testSignUpEmail,
+                isDelegated = true
+              )
+
+              mockRegisterCompany(testVatNumber, testCompanyNumber)(Future.successful(Right(RegisterWithMultipleIdsSuccess(testSafeId))))
+              mockSignUp(testSafeId, testVatNumber, Some(testEmail), emailVerified = Some(true))(Future.successful(Right(CustomerSignUpResponseSuccess)))
+              mockRegisterEnrolment(testVatNumber, testSafeId)(Future.successful(Left(FailedTaxEnrolment(BAD_REQUEST))))
+
+              val res = await(TestSubmissionService.submitSignUpRequest(signUpRequest, enrolments))
+
+              res.left.value shouldBe EnrolmentFailure
+
+              verifyAudit(RegisterWithMultipleIDsAuditModel(TestConstants.testVatNumber, Some(TestConstants.testCompanyNumber), None,
+                Some(TestConstants.testAgentReferenceNumber), isSuccess = true))
+              verifyAudit(SignUpAuditModel(TestConstants.testSafeId, TestConstants.testVatNumber, Some(TestConstants.testEmail), Some(true),
+                Some(TestConstants.testAgentReferenceNumber), isSuccess = true))
+            }
+          }
+        }
+        "the sign up request fails" should {
+          "return a SignUpFailure" in {
+            val signUpRequest = SignUpRequest(
+              vatNumber = testVatNumber,
+              businessEntity = testBusinessEntityLTD,
+              signUpEmail = Some(testSignUpEmail),
+              transactionEmail = testSignUpEmail,
+              isDelegated = true
+            )
+
+            mockRegisterCompany(testVatNumber, testCompanyNumber)(Future.successful(Right(RegisterWithMultipleIdsSuccess(testSafeId))))
+            mockSignUp(testSafeId, testVatNumber, Some(testEmail), emailVerified = Some(true))(Future.successful(Left(CustomerSignUpResponseFailure(BAD_REQUEST))))
+
+            val res = await(TestSubmissionService.submitSignUpRequest(signUpRequest, enrolments))
+
+            res.left.value shouldBe SignUpFailure
+
+            verifyAudit(RegisterWithMultipleIDsAuditModel(TestConstants.testVatNumber, Some(TestConstants.testCompanyNumber), None,
+              Some(TestConstants.testAgentReferenceNumber), isSuccess = true))
+            verifyAudit(SignUpAuditModel(TestConstants.testSafeId, TestConstants.testVatNumber, Some(TestConstants.testEmail), Some(true),
+              Some(TestConstants.testAgentReferenceNumber), isSuccess = false))
+
+          }
+        }
+      }
+      "the registration request fails" should {
+        "return a RegistrationFailure" in {
+          val signUpRequest = SignUpRequest(
+            vatNumber = testVatNumber,
+            businessEntity = testBusinessEntityLTD,
+            signUpEmail = Some(testSignUpEmail),
+            transactionEmail = testSignUpEmail,
+            isDelegated = true
+          )
+
+          mockRegisterCompany(testVatNumber, testCompanyNumber)(
+            Future.successful(Left(RegisterWithMultipleIdsErrorResponse(BAD_REQUEST, "")))
+          )
+
+          val res = await(TestSubmissionService.submitSignUpRequest(signUpRequest, enrolments))
+
+          res.left.value shouldBe RegistrationFailure
+
+          verifyAudit(RegisterWithMultipleIDsAuditModel(TestConstants.testVatNumber, Some(TestConstants.testCompanyNumber), None,
+            Some(TestConstants.testAgentReferenceNumber), isSuccess = false))
+
+        }
+      }
+    }
+    "the user is principal" when {
+      val enrolments = Enrolments(Set(testPrincipalEnrolment))
+
+      "the registration request is successful" when {
+        "the sign up request is successful" when {
+          "the enrolment call is successful" should {
+            "return a SignUpRequestSubmitted for an individual signup" in {
+              val signUpRequest = SignUpRequest(
+                vatNumber = testVatNumber,
+                businessEntity = testBusinessEntitySole,
+                signUpEmail = Some(testSignUpEmail),
+                transactionEmail = testSignUpEmail,
+                isDelegated = false
+              )
+
+
+              mockRegisterIndividual(testVatNumber, testNino)(Future.successful(Right(RegisterWithMultipleIdsSuccess(testSafeId))))
+              mockSignUp(testSafeId, testVatNumber, Some(testEmail), emailVerified = Some(true))(Future.successful(Right(CustomerSignUpResponseSuccess)))
+              mockRegisterEnrolment(testVatNumber, testSafeId)(Future.successful(Right(SuccessfulTaxEnrolment)))
+
+              val res = await(TestSubmissionService.submitSignUpRequest(signUpRequest, enrolments))
+
+              res.right.value shouldBe SignUpRequestSubmitted
+
+              verifyAudit(RegisterWithMultipleIDsAuditModel(TestConstants.testVatNumber, None, Some(TestConstants.testNino), None, isSuccess = true))
+              verifyAudit(SignUpAuditModel(TestConstants.testSafeId, TestConstants.testVatNumber, Some(TestConstants.testEmail), Some(true), None, isSuccess = true))
+            }
+            "return a SignUpRequestSubmitted for a company sign up" in {
+              val signUpRequest = SignUpRequest(
+                vatNumber = testVatNumber,
+                businessEntity = testBusinessEntityLTD,
+                signUpEmail = Some(testSignUpEmail),
+                transactionEmail = testSignUpEmail,
+                isDelegated = false
+              )
+
+
+              mockRegisterCompany(testVatNumber, testCompanyNumber)(Future.successful(Right(RegisterWithMultipleIdsSuccess(testSafeId))))
+              mockSignUp(testSafeId, testVatNumber, Some(testEmail), emailVerified = Some(true))(Future.successful(Right(CustomerSignUpResponseSuccess)))
+              mockRegisterEnrolment(testVatNumber, testSafeId)(Future.successful(Right(SuccessfulTaxEnrolment)))
+
+              val res = await(TestSubmissionService.submitSignUpRequest(signUpRequest, enrolments))
+
+              res.right.value shouldBe SignUpRequestSubmitted
+
+              verifyAudit(RegisterWithMultipleIDsAuditModel(TestConstants.testVatNumber, Some(TestConstants.testCompanyNumber), None, None, isSuccess = true))
+              verifyAudit(SignUpAuditModel(TestConstants.testSafeId, TestConstants.testVatNumber, Some(TestConstants.testEmail), Some(true), None, isSuccess = true))
+            }
+          }
+          "the enrolment call fails" should {
+            "return an EnrolmentFailure" in {
+              val signUpRequest = SignUpRequest(
+                vatNumber = testVatNumber,
+                businessEntity = testBusinessEntityLTD,
+                signUpEmail = Some(testSignUpEmail),
+                transactionEmail = testSignUpEmail,
+                isDelegated = false
+              )
+
+
+              mockRegisterCompany(testVatNumber, testCompanyNumber)(Future.successful(Right(RegisterWithMultipleIdsSuccess(testSafeId))))
+              mockSignUp(testSafeId, testVatNumber, Some(testEmail), emailVerified = Some(true))(Future.successful(Right(CustomerSignUpResponseSuccess)))
+              mockRegisterEnrolment(testVatNumber, testSafeId)(Future.successful(Left(FailedTaxEnrolment(BAD_REQUEST))))
+
+              val res = await(TestSubmissionService.submitSignUpRequest(signUpRequest, enrolments))
+
+              res.left.value shouldBe EnrolmentFailure
+
+              verifyAudit(RegisterWithMultipleIDsAuditModel(TestConstants.testVatNumber, Some(TestConstants.testCompanyNumber), None, None, isSuccess = true))
+              verifyAudit(SignUpAuditModel(TestConstants.testSafeId, TestConstants.testVatNumber, Some(TestConstants.testEmail), Some(true), None, isSuccess = true))
+            }
+          }
+        }
+        "the sign up request fails" should {
+          "return a SignUpFailure" in {
+            val signUpRequest = SignUpRequest(
+              vatNumber = testVatNumber,
+              businessEntity = testBusinessEntityLTD,
+              signUpEmail = Some(testSignUpEmail),
+              transactionEmail = testSignUpEmail,
+              isDelegated = false
+            )
+
+
+            mockRegisterCompany(testVatNumber, testCompanyNumber)(Future.successful(Right(RegisterWithMultipleIdsSuccess(testSafeId))))
+            mockSignUp(testSafeId, testVatNumber, Some(testEmail), emailVerified = Some(true))(Future.successful(Left(CustomerSignUpResponseFailure(BAD_REQUEST))))
+
+            val res = await(TestSubmissionService.submitSignUpRequest(signUpRequest, enrolments))
+
+            res.left.value shouldBe SignUpFailure
+
+            verifyAudit(RegisterWithMultipleIDsAuditModel(TestConstants.testVatNumber, Some(TestConstants.testCompanyNumber), None, None, isSuccess = true))
+            verifyAudit(SignUpAuditModel(TestConstants.testSafeId, TestConstants.testVatNumber, Some(TestConstants.testEmail), Some(true), None, isSuccess = false))
+          }
+        }
+      }
+      "the registration request fails" should {
+        "return a RegistrationFailure" in {
+          val signUpRequest = SignUpRequest(
+            vatNumber = testVatNumber,
+            businessEntity = testBusinessEntityLTD,
+            signUpEmail = Some(testSignUpEmail),
+            transactionEmail = testSignUpEmail,
+            isDelegated = false
+          )
+
+          mockRegisterCompany(testVatNumber, testCompanyNumber)(
+            Future.successful(Left(RegisterWithMultipleIdsErrorResponse(BAD_REQUEST, "")))
+          )
+
+          val res = await(TestSubmissionService.submitSignUpRequest(signUpRequest, enrolments))
+
+          res.left.value shouldBe RegistrationFailure
+
+          verifyAudit(RegisterWithMultipleIDsAuditModel(TestConstants.testVatNumber, Some(TestConstants.testCompanyNumber), None, None, isSuccess = false))
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Substitute the old SignUpSubmissionService, so that we can separate
  concerns. Specifically, we ditch everything related to email verification
  and data storage, as those are to be handled by different services.