### PR TITLE
SAR-2508: Send agent email in tax enrolment callback

### DIFF
--- a/app/uk/gov/hmrc/vatsignup/connectors/EmailConnector.scala
+++ b/app/uk/gov/hmrc/vatsignup/connectors/EmailConnector.scala
@@ -30,11 +30,16 @@ import scala.concurrent.{ExecutionContext, Future}
 class EmailConnector @Inject()(http: HttpClient,
                                appConfig: AppConfig
                               )(implicit ec: ExecutionContext) {
-  def sendEmail(emailAddress: String, emailTemplate: String)(implicit hc: HeaderCarrier): Future[SendEmailResponse] = {
+  def sendEmail(emailAddress: String,
+                emailTemplate: String,
+                vatNumber: Option[String])(implicit hc: HeaderCarrier): Future[SendEmailResponse] = {
     val body = Json.obj(
       toKey -> Json.arr(emailAddress),
       templateIdKey -> emailTemplate
-    )
+    ) ++ (vatNumber match {
+      case None => Json.obj()
+      case Some(vn) => Json.obj(parametersKey -> Json.obj(vatNumberKey -> vn))
+    })
 
     http.POST(appConfig.sendEmailUrl, body)
   }
@@ -43,4 +48,6 @@ class EmailConnector @Inject()(http: HttpClient,
 object EmailConnector {
   val toKey = "to"
   val templateIdKey = "templateId"
+  val vatNumberKey = "vatNumber"
+  val parametersKey = "parameters"
 }

--- a/it/uk/gov/hmrc/vatsignup/connectors/EmailConnectorISpec.scala
+++ b/it/uk/gov/hmrc/vatsignup/connectors/EmailConnectorISpec.scala
@@ -34,17 +34,39 @@ class EmailConnectorISpec extends ComponentSpecBase {
       "return a SuccessfulTaxEnrolment" in {
         EmailStub.stubSendEmail(testEmail, testEmailTemplate)(ACCEPTED)
 
-        val res = connector.sendEmail(testEmail, testEmailTemplate)
+        val res = connector.sendEmail(testEmail, testEmailTemplate, None)
 
         await(res) shouldBe Right(EmailQueued)
       }
     }
 
-    "Tax Enrolments returns a unsuceessful response" should {
+    "Tax Enrolments returns a unsuccessful response" should {
       "return a FailedTaxEnrolment" in {
         EmailStub.stubSendEmail(testEmail, testEmailTemplate)(BAD_REQUEST)
 
-        val res = connector.sendEmail(testEmail, testEmailTemplate)
+        val res = connector.sendEmail(testEmail, testEmailTemplate, None)
+
+        await(res) shouldBe Left(SendEmailFailure(BAD_REQUEST, ""))
+      }
+    }
+  }
+
+  "registerEnrolment when is delegated" when {
+    "Tax Enrolments returns a successful response" should {
+      "return a SuccessfulTaxEnrolment" in {
+        EmailStub.stubSendEmailDelegated(testEmail, testEmailTemplate, testVatNumber)(ACCEPTED)
+
+        val res = connector.sendEmail(testEmail, testEmailTemplate, Some(testVatNumber))
+
+        await(res) shouldBe Right(EmailQueued)
+      }
+    }
+
+    "Tax Enrolments returns a unsuccessful response" should {
+      "return a FailedTaxEnrolment" in {
+        EmailStub.stubSendEmailDelegated(testEmail, testEmailTemplate, testVatNumber)(BAD_REQUEST)
+
+        val res = connector.sendEmail(testEmail, testEmailTemplate, Some(testVatNumber))
 
         await(res) shouldBe Left(SendEmailFailure(BAD_REQUEST, ""))
       }

--- a/it/uk/gov/hmrc/vatsignup/helpers/servicemocks/EmailStub.scala
+++ b/it/uk/gov/hmrc/vatsignup/helpers/servicemocks/EmailStub.scala
@@ -35,4 +35,18 @@ object EmailStub extends WireMockMethods {
       body = sendEmailJsonBody
     ) thenReturn status
   }
+
+  def stubSendEmailDelegated(emailAddress: String, emailTemplate: String, vatNumber: String)(status: Int): Unit = {
+    val sendEmailJsonBody = Json.obj(
+      "to" -> Json.arr(emailAddress),
+      "templateId" -> emailTemplate,
+      "parameters" -> Json.obj("vatNumber" -> vatNumber)
+    )
+
+    when(
+      method = POST,
+      uri = sendEmailUri,
+      body = sendEmailJsonBody
+    ) thenReturn status
+  }
 }

--- a/test/uk/gov/hmrc/vatsignup/connectors/mocks/MockEmailConnector.scala
+++ b/test/uk/gov/hmrc/vatsignup/connectors/mocks/MockEmailConnector.scala
@@ -37,10 +37,13 @@ trait MockEmailConnector extends MockitoSugar with BeforeAndAfterEach {
 
   val mockEmailConnector: EmailConnector = mock[EmailConnector]
 
-  def mockSendEmail(emailAddress: String, emailTemplate: String)(response: Future[SendEmailResponse]): Unit =
+  def mockSendEmail(emailAddress: String,
+                    emailTemplate: String,
+                    vatNumber: Option[String])(response: Future[SendEmailResponse]): Unit =
     when(mockEmailConnector.sendEmail(
       ArgumentMatchers.eq(emailAddress),
-      ArgumentMatchers.eq(emailTemplate)
+      ArgumentMatchers.eq(emailTemplate),
+      ArgumentMatchers.eq(vatNumber)
     )(
       ArgumentMatchers.any[HeaderCarrier]
     )) thenReturn response


### PR DESCRIPTION
Add a call to send the agent email when isDelegated is
true, rather than just returning a state in the tax
enrolment callback.