### PR TITLE
SAR-3271: Add Overseas BE

### DIFF
--- a/app/uk/gov/hmrc/vatsignup/connectors/EntityTypeRegistrationConnector.scala
+++ b/app/uk/gov/hmrc/vatsignup/connectors/EntityTypeRegistrationConnector.scala
@@ -66,6 +66,7 @@ object EntityTypeRegistrationConnector {
   val RegisteredSocietyKey = "registeredSociety"
   val CharityKey = "charitableIncorporatedOrganisation"
   val GovernmentOrganisationKey = "publicBody"
+  val OverseasKey = "nonUKCompanyNoUKEstablishment"
 
   val VrnKey = "vrn"
   val NinoKey = "nino"
@@ -158,6 +159,12 @@ object EntityTypeRegistrationConnector {
     case GovernmentOrganisation =>
       Json.obj(
         GovernmentOrganisationKey -> Json.obj(
+          VrnKey -> vatNumber
+        )
+      )
+    case Overseas =>
+      Json.obj(
+        OverseasKey -> Json.obj(
           VrnKey -> vatNumber
         )
       )

--- a/app/uk/gov/hmrc/vatsignup/controllers/StoreOverseasController.scala
+++ b/app/uk/gov/hmrc/vatsignup/controllers/StoreOverseasController.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignup.controllers
+
+import javax.inject.{Inject, Singleton}
+import play.api.mvc.{Action, AnyContent}
+import uk.gov.hmrc.auth.core.{AuthConnector, AuthorisedFunctions}
+import uk.gov.hmrc.play.bootstrap.controller.BaseController
+import uk.gov.hmrc.vatsignup.services.StoreOverseasService
+import uk.gov.hmrc.vatsignup.services.StoreOverseasService._
+
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class StoreOverseasController @Inject()(val authConnector: AuthConnector,
+                                        storeOverseasService: StoreOverseasService
+                                       )(implicit ec: ExecutionContext) extends BaseController with AuthorisedFunctions {
+
+  def storeOverseas(vatNumber: String): Action[AnyContent] = Action.async {
+    implicit req => authorised() {
+      storeOverseasService.storeOverseas(vatNumber) map {
+        case Right(_) => NoContent
+        case Left(OverseasDatabaseFailureNoVATNumber) => NotFound
+        case Left(_) => InternalServerError
+      }
+    }
+  }
+
+}

--- a/app/uk/gov/hmrc/vatsignup/models/BusinessEntity.scala
+++ b/app/uk/gov/hmrc/vatsignup/models/BusinessEntity.scala
@@ -50,6 +50,8 @@ case object Charity extends BusinessEntity
 
 case object GovernmentOrganisation extends BusinessEntity
 
+case object Overseas extends BusinessEntity
+
 object BusinessEntity {
   val EntityTypeKey = "entityType"
   val LimitedCompanyKey = "limitedCompany"
@@ -65,6 +67,7 @@ object BusinessEntity {
   val RegisteredSocietyKey = "registeredSociety"
   val CharityKey = "charity"
   val NonUkWithUKEstablishmentKey = "nonUKCompanyWithUKEstablishment"
+  val OverseasKey = "nonUKCompanyNoUKEstablishment"
   val GovernmentOrganisationKey = "governmentOrganisation"
 
   val NinoKey = "nino"
@@ -136,6 +139,10 @@ object BusinessEntity {
         Json.obj(
           EntityTypeKey -> GovernmentOrganisationKey
         )
+      case Overseas =>
+        Json.obj(
+          EntityTypeKey -> OverseasKey
+        )
     }
 
     override def reads(json: JsValue): JsResult[BusinessEntity] =
@@ -185,6 +192,8 @@ object BusinessEntity {
             JsSuccess(Charity)
           case GovernmentOrganisationKey =>
             JsSuccess(GovernmentOrganisation)
+          case OverseasKey =>
+            JsSuccess(Overseas)
         }
       } yield businessEntity
   }

--- a/app/uk/gov/hmrc/vatsignup/services/StoreOverseasService.scala
+++ b/app/uk/gov/hmrc/vatsignup/services/StoreOverseasService.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignup.services
+
+import javax.inject.{Inject, Singleton}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.vatsignup.models.Overseas
+import uk.gov.hmrc.vatsignup.repositories.SubscriptionRequestRepository
+import uk.gov.hmrc.vatsignup.services.StoreOverseasService._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class StoreOverseasService @Inject()(subscriptionRequestRepository: SubscriptionRequestRepository)(implicit ec: ExecutionContext) {
+
+  def storeOverseas(vatNumber: String)(implicit hc: HeaderCarrier): Future[Either[StoreOverseasFailure, StoreOverseasSuccess.type]] = {
+
+    subscriptionRequestRepository.upsertBusinessEntity(vatNumber, Overseas) map {
+      _ => Right(StoreOverseasSuccess)
+    } recover {
+      case e: NoSuchElementException => Left(OverseasDatabaseFailureNoVATNumber)
+      case _ => Left(OverseasDatabaseFailure)
+    }
+  }
+
+}
+
+object StoreOverseasService {
+
+  case object StoreOverseasSuccess
+
+  sealed trait StoreOverseasFailure
+
+  case object OverseasDatabaseFailure extends StoreOverseasFailure
+
+  case object OverseasDatabaseFailureNoVATNumber extends StoreOverseasFailure
+
+}

--- a/conf/deprecated.routes
+++ b/conf/deprecated.routes
@@ -15,6 +15,7 @@ POST        /subscription-request/vat-number/:vatNumber/trust                   
 POST        /subscription-request/vat-number/:vatNumber/registered-society           @uk.gov.hmrc.vatsignup.controllers.StoreRegisteredSocietyController.storeRegisteredSociety(vatNumber: String)
 POST        /subscription-request/vat-number/:vatNumber/charity                      @uk.gov.hmrc.vatsignup.controllers.StoreCharityController.storeCharity(vatNumber: String)
 POST        /subscription-request/vat-number/:vatNumber/government-organisation      @uk.gov.hmrc.vatsignup.controllers.StoreGovernmentOrganisationController.storeGovernmentOrganisation(vatNumber: String)
+POST        /subscription-request/vat-number/:vatNumber/overseas                     @uk.gov.hmrc.vatsignup.controllers.StoreOverseasController.storeOverseas(vatNumber: String)
 
 GET         /subscription-request/vat-number/:vatNumber/mtdfb-eligibility            @uk.gov.hmrc.vatsignup.controllers.VatNumberEligibilityController.checkVatNumberEligibility(vatNumber: String)
 

--- a/it/uk/gov/hmrc/vatsignup/controllers/StoreOverseasControllerISpec.scala
+++ b/it/uk/gov/hmrc/vatsignup/controllers/StoreOverseasControllerISpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2018 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignup.controllers
+
+import play.api.http.Status._
+import play.api.libs.json.Json
+import uk.gov.hmrc.vatsignup.helpers.IntegrationTestConstants._
+import uk.gov.hmrc.vatsignup.helpers._
+import uk.gov.hmrc.vatsignup.helpers.servicemocks.AuthStub._
+import uk.gov.hmrc.vatsignup.models._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+class StoreOverseasControllerISpec extends ComponentSpecBase with CustomMatchers with TestSubmissionRequestRepository {
+
+  "POST /subscription-request/vat-number/:vatNumber/overseas" should {
+    "return NO_CONTENT" in {
+      stubAuth(OK, successfulAuthResponse())
+
+      await(submissionRequestRepo.upsertVatNumber(testVatNumber, isMigratable = true))
+
+      val res = post(s"/subscription-request/vat-number/$testVatNumber/overseas")(Json.obj())
+
+      res should have(
+        httpStatus(NO_CONTENT),
+        emptyBody
+      )
+
+      val dbRequest = await(submissionRequestRepo.findById(testVatNumber)).get
+      dbRequest.businessEntity shouldBe Some(Overseas)
+    }
+  }
+}

--- a/it/uk/gov/hmrc/vatsignup/repositories/SubscriptionRequestRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/vatsignup/repositories/SubscriptionRequestRepositoryISpec.scala
@@ -334,6 +334,20 @@ class SubscriptionRequestRepositoryISpec extends UnitSpec with GuiceOneAppPerSui
         businessEntity = Some(Charity)
       ))
     }
+
+    "store an Overseas company" in {
+      val res = for {
+        _ <- repo.upsertVatNumber(testVatNumber, isMigratable = true)
+        _ <- repo.upsertBusinessEntity(testVatNumber, Overseas)
+        model <- repo.findById(testVatNumber)
+      } yield model
+
+      await(res) shouldBe Some(SubscriptionRequest(
+        vatNumber = testVatNumber,
+        isMigratable = true,
+        businessEntity = Some(Overseas)
+      ))
+    }
   }
 
   "upsertCtReference" should {

--- a/test/uk/gov/hmrc/vatsignup/controllers/StoreOverseasControllerSpec.scala
+++ b/test/uk/gov/hmrc/vatsignup/controllers/StoreOverseasControllerSpec.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignup.controllers
+
+import akka.actor.ActorSystem
+import akka.stream.ActorMaterializer
+import play.api.http.Status._
+import play.api.mvc.Result
+import play.api.test.FakeRequest
+import uk.gov.hmrc.auth.core.retrieve.EmptyRetrieval
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.vatsignup.connectors.mocks.MockAuthConnector
+import uk.gov.hmrc.vatsignup.helpers.TestConstants._
+import uk.gov.hmrc.vatsignup.service.mocks.MockStoreOverseasService
+import uk.gov.hmrc.vatsignup.services.StoreOverseasService._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class StoreOverseasControllerSpec extends UnitSpec with MockAuthConnector with MockStoreOverseasService {
+
+  implicit val system: ActorSystem = ActorSystem()
+  implicit val materializer: ActorMaterializer = ActorMaterializer()
+
+  object TestStoreOverseasController extends StoreOverseasController(
+    mockAuthConnector,
+    mockStoreOverseasService
+  )
+
+
+  "storeOverseas" when {
+    "is successful" should {
+      "return NO_CONTENT" in {
+        mockAuthorise(retrievals = EmptyRetrieval)(Future.successful(Unit))
+        mockStoreOverseas(testVatNumber)(Future.successful(Right(StoreOverseasSuccess)))
+
+        val result: Result = await(TestStoreOverseasController.storeOverseas(testVatNumber)(FakeRequest()))
+
+        status(result) shouldBe NO_CONTENT
+
+      }
+    }
+    "fails with OverseasDatabaseFailureNoVATNumber" should {
+      "return NOT_FOUND" in {
+        mockAuthorise(retrievals = EmptyRetrieval)(Future.successful(Unit))
+        mockStoreOverseas(testVatNumber)(Future.successful(Left(OverseasDatabaseFailureNoVATNumber)))
+
+        val result: Result = await(TestStoreOverseasController.storeOverseas(testVatNumber)(FakeRequest()))
+
+        status(result) shouldBe NOT_FOUND
+
+      }
+    }
+    "fails with OverseasDatabaseFailure" should {
+      "return INTERNAL_SERVER_ERROR" in {
+        mockAuthorise(retrievals = EmptyRetrieval)(Future.successful(Unit))
+        mockStoreOverseas(testVatNumber)(Future.successful(Left(OverseasDatabaseFailure)))
+
+        val result: Result = await(TestStoreOverseasController.storeOverseas(testVatNumber)(FakeRequest()))
+
+        status(result) shouldBe INTERNAL_SERVER_ERROR
+
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/vatsignup/service/StoreOverseasServiceSpec.scala
+++ b/test/uk/gov/hmrc/vatsignup/service/StoreOverseasServiceSpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignup.service
+
+import play.api.mvc.Request
+import play.api.test.FakeRequest
+import reactivemongo.api.commands.UpdateWriteResult
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.test.UnitSpec
+import uk.gov.hmrc.vatsignup.helpers.TestConstants._
+import uk.gov.hmrc.vatsignup.models.Overseas
+import uk.gov.hmrc.vatsignup.repositories.mocks.MockSubscriptionRequestRepository
+import uk.gov.hmrc.vatsignup.services.StoreOverseasService
+import uk.gov.hmrc.vatsignup.services.StoreOverseasService._
+
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
+
+class StoreOverseasServiceSpec extends UnitSpec
+  with MockSubscriptionRequestRepository {
+
+  object TestStoreOverseasService extends StoreOverseasService(mockSubscriptionRequestRepository)
+
+  implicit val hc: HeaderCarrier = HeaderCarrier()
+  implicit val request: Request[_] = FakeRequest()
+
+
+  "storeOverseas" when {
+    "upsertBusinessEntity is successful" should {
+      "return StoreOverseasSuccess" in {
+        mockUpsertBusinessEntity(testVatNumber, Overseas)(Future.successful(mock[UpdateWriteResult]))
+
+        val res = TestStoreOverseasService.storeOverseas(testVatNumber)
+
+        await(res) shouldBe Right(StoreOverseasSuccess)
+
+      }
+    }
+    "upsertBusinessEntity returns OverseasDatabaseFailure" should {
+      "return StoreOverseasFailure" in {
+        mockUpsertBusinessEntity(testVatNumber, Overseas)(Future.failed(new Exception))
+
+        val res = TestStoreOverseasService.storeOverseas(testVatNumber)
+
+        await(res) shouldBe Left(OverseasDatabaseFailure)
+
+      }
+    }
+    "upsertBusinessEntity throws NoSuchElementException" should {
+      "return OverseasDatabaseFailureNoVATNumber" in {
+        mockUpsertBusinessEntity(testVatNumber, Overseas)(Future.failed(new NoSuchElementException))
+
+        val res = TestStoreOverseasService.storeOverseas(testVatNumber)
+
+        await(res) shouldBe Left(OverseasDatabaseFailureNoVATNumber)
+
+      }
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/vatsignup/service/mocks/MockStoreOverseasService.scala
+++ b/test/uk/gov/hmrc/vatsignup/service/mocks/MockStoreOverseasService.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.vatsignup.service.mocks
+
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito._
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.vatsignup.services.StoreOverseasService
+import uk.gov.hmrc.vatsignup.services.StoreOverseasService.{StoreOverseasFailure, StoreOverseasSuccess}
+
+import scala.concurrent.Future
+
+trait MockStoreOverseasService extends MockitoSugar with BeforeAndAfterEach {
+  self: Suite =>
+
+  val mockStoreOverseasService: StoreOverseasService = mock[StoreOverseasService]
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockStoreOverseasService)
+  }
+
+  def mockStoreOverseas(vatNumber: String)(response: Future[Either[StoreOverseasFailure, StoreOverseasSuccess.type]]): Unit =
+    when(mockStoreOverseasService.storeOverseas(
+      ArgumentMatchers.eq(vatNumber)
+    )(ArgumentMatchers.any[HeaderCarrier])) thenReturn response
+
+}


### PR DESCRIPTION
Add new overseas business entity which described the
non uk with no uk establishment companies in etmp.
They also tend to be called NETPs.

- Add new BE
- update call to etmp to send the BE
- Create service, route and controller to store the BE