### PR TITLE
SAR-3315: Update connector to support new fields

### DIFF
--- a/it/uk/gov/hmrc/vatsignup/connectors/KnownFactsAndControlListInformationConnectorISpec.scala
+++ b/it/uk/gov/hmrc/vatsignup/connectors/KnownFactsAndControlListInformationConnectorISpec.scala
@@ -37,7 +37,13 @@ class KnownFactsAndControlListInformationConnectorISpec extends ComponentSpecBas
 
         val res = await(KnownFactsAndControlListInformationConnector.getKnownFactsAndControlListInformation(testVatNumber))
 
-        res.right.value shouldBe KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, eligibleModel)
+        res.right.value shouldBe KnownFactsAndControlListInformation(
+          businessPostcode = testPostCode,
+          vatRegistrationDate = testDateOfRegistration,
+          lastReturnMonthPeriod = Some(testLastReturnMonthPeriod),
+          lastNetDue = Some(testLastNetDue),
+          controlListInformation = eligibleModel
+        )
       }
     }
   }

--- a/it/uk/gov/hmrc/vatsignup/helpers/IntegrationTestConstants.scala
+++ b/it/uk/gov/hmrc/vatsignup/helpers/IntegrationTestConstants.scala
@@ -41,6 +41,8 @@ object IntegrationTestConstants {
 
   val testPostCode = "ZZ11 1ZZ"
   val testDateOfRegistration = "2017-01-01"
+  val testLastReturnMonthPeriod: String = "MAR"
+  val testLastNetDue: Double = 10000.02
 
   val eligibleModel: ControlListInformation = ControlListInformation(
     controlList = Set(Stagger1, Company),

--- a/it/uk/gov/hmrc/vatsignup/helpers/servicemocks/KnownFactsAndControlListInformationStub.scala
+++ b/it/uk/gov/hmrc/vatsignup/helpers/servicemocks/KnownFactsAndControlListInformationStub.scala
@@ -89,6 +89,8 @@ object KnownFactsAndControlListInformationStub extends WireMockMethods {
     Json.obj(
       "postcode" -> testPostCode,
       "dateOfReg" -> testDateOfRegistration,
+      "lastReturnMonthPeriod" -> testLastReturnMonthPeriod,
+      "lastNetDue" -> testLastNetDue,
       "controlListInformation" -> ControlList33.eligible
     )
 

--- a/test/uk/gov/hmrc/vatsignup/helpers/TestConstants.scala
+++ b/test/uk/gov/hmrc/vatsignup/helpers/TestConstants.scala
@@ -59,6 +59,8 @@ object TestConstants {
 
   val testPostCode = "ZZ11 1ZZ"
   val testDateOfRegistration = "2017-01-01"
+  val testLastReturnMonthPeriod: String = "MAR"
+  val testLastNetDue: Double = 10000.02
 
   val testAgentEnrolment: Enrolment = Enrolment(AgentEnrolmentKey).withIdentifier(AgentReferenceNumberKey, testAgentReferenceNumber)
   val testPrincipalEnrolment: Enrolment = Enrolment(VatDecEnrolmentKey).withIdentifier(VatReferenceKey, testVatNumber)
@@ -84,6 +86,8 @@ object TestConstants {
   val testKnownFactsAndControlListInformation = KnownFactsAndControlListInformation(
     testPostCode,
     testDateOfRegistration,
+    Some(testLastReturnMonthPeriod),
+    Some(testLastNetDue),
     testControlListInformation
   )
 

--- a/test/uk/gov/hmrc/vatsignup/httpparsers/KnownFactsAndControlListInformationHttpParserSpec.scala
+++ b/test/uk/gov/hmrc/vatsignup/httpparsers/KnownFactsAndControlListInformationHttpParserSpec.scala
@@ -39,12 +39,20 @@ class KnownFactsAndControlListInformationHttpParserSpec extends UnitSpec with Ei
               Json.obj(
                 "postcode" -> testPostCode,
                 "dateOfReg" -> testDateOfRegistration,
+                "lastReturnMonthPeriod" -> testLastReturnMonthPeriod,
+                "lastNetDue" -> testLastNetDue,
                 "controlListInformation" -> ControlList32.valid
               )
             )
           )
 
-          read(testMethod, testUrl, testResponse) shouldBe Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, testControlListInformation))
+          read(testMethod, testUrl, testResponse) shouldBe Right(KnownFactsAndControlListInformation(
+            testPostCode,
+            testDateOfRegistration,
+            Some(testLastReturnMonthPeriod),
+            Some(testLastNetDue),
+            testControlListInformation
+          ))
         }
       }
 
@@ -60,7 +68,11 @@ class KnownFactsAndControlListInformationHttpParserSpec extends UnitSpec with Ei
             responseJson = Some(testJson)
           )
 
-          val res: UnexpectedKnownFactsAndControlListInformationFailure = read(testMethod, testUrl, testResponse).left.value.asInstanceOf[UnexpectedKnownFactsAndControlListInformationFailure]
+          val res: UnexpectedKnownFactsAndControlListInformationFailure = read(
+            method = testMethod,
+            url = testUrl,
+            response = testResponse
+          ).left.value.asInstanceOf[UnexpectedKnownFactsAndControlListInformationFailure]
 
           res.status shouldBe OK
           res.body should include(invalidJsonResponseMessage)

--- a/test/uk/gov/hmrc/vatsignup/service/ControlListEligibilityServiceSpec.scala
+++ b/test/uk/gov/hmrc/vatsignup/service/ControlListEligibilityServiceSpec.scala
@@ -61,7 +61,7 @@ class ControlListEligibilityServiceSpec extends UnitSpec
           )
 
           mockGetKnownFactsAndControlListInformation(testVatNumber)(
-            Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, overseasControlListInformation)))
+            Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, None, None, overseasControlListInformation)))
           )
 
           val res = await(TestControlListEligibilityService.getEligibilityStatus(testVatNumber))
@@ -73,7 +73,7 @@ class ControlListEligibilityServiceSpec extends UnitSpec
       "the user is not an overseas trader" should {
         "return EligibilitySuccess with the known facts, a migration status of true and an overseas status of true" in {
           mockGetKnownFactsAndControlListInformation(testVatNumber)(
-            Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, testControlListInformation))))
+            Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, None, None, testControlListInformation))))
 
           val res = await(TestControlListEligibilityService.getEligibilityStatus(testVatNumber))
 
@@ -87,7 +87,7 @@ class ControlListEligibilityServiceSpec extends UnitSpec
       "return EligibilitySuccess with the known facts and a migration status of true" in {
         mockNonMigratableParameters(Set(Stagger1))
         mockGetKnownFactsAndControlListInformation(testVatNumber)(
-          Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, testControlListInformation))))
+          Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, None, None, testControlListInformation))))
 
         val res = await(TestControlListEligibilityService.getEligibilityStatus(testVatNumber))
 
@@ -100,7 +100,7 @@ class ControlListEligibilityServiceSpec extends UnitSpec
       "return IneligibleVatNumber" in {
         mockIneligibleParameters(Set(Stagger1))
         mockGetKnownFactsAndControlListInformation(testVatNumber)(
-          Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, testControlListInformation))))
+          Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, None, None, testControlListInformation))))
 
         val res = await(TestControlListEligibilityService.getEligibilityStatus(testVatNumber))
 
@@ -119,7 +119,7 @@ class ControlListEligibilityServiceSpec extends UnitSpec
         val testControlListInformation = ControlListInformation(Set(DirectDebit, Stagger1, Company), Stagger1, Company)
 
         mockGetKnownFactsAndControlListInformation(testVatNumber)(
-          Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, testControlListInformation))))
+          Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, None, None, testControlListInformation))))
 
         mockCheckMigrationDate(Stagger1)(Left(testMigratableDates))
 
@@ -141,7 +141,7 @@ class ControlListEligibilityServiceSpec extends UnitSpec
         val testControlListInformation = ControlListInformation(Set(DirectDebit, Stagger1, Company), Stagger1, Company)
 
         mockGetKnownFactsAndControlListInformation(testVatNumber)(
-          Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, testControlListInformation))))
+          Future.successful(Right(KnownFactsAndControlListInformation(testPostCode, testDateOfRegistration, None, None, testControlListInformation))))
 
         mockCheckMigrationDate(Stagger1)(Right(DirectDebitMigrationCheckService.Eligible))
 


### PR DESCRIPTION
We are adding two fields in the known facts and control list
connector. The reason for it, is that we will now support
both 2 and 4 factor known facts questions.